### PR TITLE
Add CRUD endpoints for country API

### DIFF
--- a/src/main/java/co/edu/uco/reactiveexample/controller/PaisController.java
+++ b/src/main/java/co/edu/uco/reactiveexample/controller/PaisController.java
@@ -2,10 +2,18 @@ package co.edu.uco.reactiveexample.controller;
 
 import co.edu.uco.reactiveexample.entity.CountryEntity;
 import co.edu.uco.reactiveexample.repository.CountryRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/v1/countries")
@@ -22,5 +30,35 @@ public class PaisController {
     @GetMapping
     public Flux<CountryEntity> getAllCountries() {
         return repository.findAll();
+    }
+
+    @PostMapping
+    public Mono<ResponseEntity<CountryEntity>> createCountry(@RequestBody final CountryEntity country) {
+        country.setId(null);
+        return repository.save(country)
+                .map(savedCountry -> ResponseEntity.status(HttpStatus.CREATED).body(savedCountry));
+    }
+
+    @PutMapping("/{id}")
+    public Mono<ResponseEntity<CountryEntity>> updateCountry(@PathVariable final Integer id,
+                                                             @RequestBody final CountryEntity country) {
+        return repository.findById(id)
+                .flatMap(existingCountry -> {
+                    existingCountry.setName(country.getName());
+                    existingCountry.setDialingCountryCode(country.getDialingCountryCode());
+                    existingCountry.setIsoCountryCode(country.getIsoCountryCode());
+                    existingCountry.setEnabled(country.getEnabled());
+                    return repository.save(existingCountry);
+                })
+                .map(ResponseEntity::ok)
+                .defaultIfEmpty(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<ResponseEntity<Void>> deleteCountry(@PathVariable final Integer id) {
+        return repository.findById(id)
+                .flatMap(existingCountry -> repository.delete(existingCountry)
+                        .then(Mono.just(ResponseEntity.noContent().build())))
+                .defaultIfEmpty(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/co/edu/uco/reactiveexample/entity/CountryEntity.java
+++ b/src/main/java/co/edu/uco/reactiveexample/entity/CountryEntity.java
@@ -28,7 +28,7 @@ public final class CountryEntity {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -55,5 +55,13 @@ public final class CountryEntity {
 
     public void setIsoCountryCode(String isoCountryCode) {
         this.isoCountryCode = Objects.requireNonNullElse(isoCountryCode, "").trim();
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
     }
 }


### PR DESCRIPTION
## Summary
- add POST, PUT and DELETE reactive endpoints to manage countries
- expose the enabled flag on CountryEntity for use by the API

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e46c3ee3c0832a8bb7be081b10a9f3