### PR TITLE
Configure Maven compiler plugin for Java 21 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
## Summary
- ensure the build uses the Maven Compiler Plugin so classes are produced with the configured Java release

## Testing
- `./mvnw clean test` *(fails: unable to download Maven distribution due to network restriction in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48f677cb4832a9b18decd2baab98a