### PR TITLE
Refactor country API to use service layer

### DIFF
--- a/src/main/java/co/edu/uco/reactiveexample/service/CountryService.java
+++ b/src/main/java/co/edu/uco/reactiveexample/service/CountryService.java
@@ -1,0 +1,16 @@
+package co.edu.uco.reactiveexample.service;
+
+import co.edu.uco.reactiveexample.entity.CountryEntity;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface CountryService {
+
+    Flux<CountryEntity> getAllCountries();
+
+    Mono<CountryEntity> createCountry(CountryEntity country);
+
+    Mono<CountryEntity> updateCountry(Integer id, CountryEntity country);
+
+    Mono<Boolean> deleteCountry(Integer id);
+}

--- a/src/main/java/co/edu/uco/reactiveexample/service/impl/CountryServiceImpl.java
+++ b/src/main/java/co/edu/uco/reactiveexample/service/impl/CountryServiceImpl.java
@@ -1,0 +1,48 @@
+package co.edu.uco.reactiveexample.service.impl;
+
+import co.edu.uco.reactiveexample.entity.CountryEntity;
+import co.edu.uco.reactiveexample.repository.CountryRepository;
+import co.edu.uco.reactiveexample.service.CountryService;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class CountryServiceImpl implements CountryService {
+
+    private final CountryRepository repository;
+
+    public CountryServiceImpl(final CountryRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Flux<CountryEntity> getAllCountries() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Mono<CountryEntity> createCountry(final CountryEntity country) {
+        country.setId(null);
+        return repository.save(country);
+    }
+
+    @Override
+    public Mono<CountryEntity> updateCountry(final Integer id, final CountryEntity country) {
+        return repository.findById(id)
+                .flatMap(existingCountry -> {
+                    existingCountry.setName(country.getName());
+                    existingCountry.setDialingCountryCode(country.getDialingCountryCode());
+                    existingCountry.setIsoCountryCode(country.getIsoCountryCode());
+                    existingCountry.setEnabled(country.getEnabled());
+                    return repository.save(existingCountry);
+                });
+    }
+
+    @Override
+    public Mono<Boolean> deleteCountry(final Integer id) {
+        return repository.findById(id)
+                .flatMap(existingCountry -> repository.delete(existingCountry).thenReturn(true))
+                .defaultIfEmpty(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add a CountryService abstraction to handle country CRUD operations
- implement the service in CountryServiceImpl and inject it into the controller
- update PaisController to delegate repository access to the new service layer

## Testing
- ./mvnw -q test *(fails: unable to download Maven binaries in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c136db44832a833ff14644bfb2c5