### PR TITLE
Fix reactive country publisher and service wiring

### DIFF
--- a/src/main/java/co/edu/uco/reactiveexample/publisher/CountryPublisher.java
+++ b/src/main/java/co/edu/uco/reactiveexample/publisher/CountryPublisher.java
@@ -1,22 +1,29 @@
 package co.edu.uco.reactiveexample.publisher;
+
 import co.edu.uco.reactiveexample.entity.CountryEntity;
 import co.edu.uco.reactiveexample.publisher.event.CountryEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
+@Component
 public class CountryPublisher {
-	
-	private final Sinks.Many<CountryEvent> sink= Sinks.many().multicast().onBackpressureBuffer();
-	
-	public void sendCreateEvent(final CountryEntity country) {
-		sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.CREATED));
-	}
-	
-	public void sendCreateEvent(final CountryEntity country) {
-		sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.UPDATED));
-	}
-	
-	public void sendCreateEvent(final CountryEntity country) {
-		sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.DELETED));
-	}
 
+    private final Sinks.Many<CountryEvent> sink = Sinks.many().multicast().onBackpressureBuffer();
+
+    public void sendCreateEvent(final CountryEntity country) {
+        sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.CREATED));
+    }
+
+    public void sendUpdateEvent(final CountryEntity country) {
+        sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.UPDATED));
+    }
+
+    public void sendDeleteEvent(final CountryEntity country) {
+        sink.tryEmitNext(new CountryEvent(country, CountryEvent.EventType.DELETED));
+    }
+
+    public Flux<CountryEvent> getEvents() {
+        return sink.asFlux();
+    }
 }


### PR DESCRIPTION
## Summary
- fix the country event publisher so each event type is emitted through a dedicated method and expose a Flux stream
- inject the publisher into the country service, trigger events on create/update/delete, and return the correct reactive types

## Testing
- `./mvnw -q test` *(fails: wget unable to download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cebfd720832a900fdffdc8907b45